### PR TITLE
[osmocom-python] Ignore package build products

### DIFF
--- a/osmocom-python/.gitignore
+++ b/osmocom-python/.gitignore
@@ -2,3 +2,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+### build artifacts ###
+*.egg-info
+build/


### PR DESCRIPTION
Packaging the osmocom python library with FPM generates some artifacts that are not covered under the existing gitignore.