### PR TITLE
[client] Fix malformed yaml

### DIFF
--- a/client/deploy/base.yml
+++ b/client/deploy/base.yml
@@ -22,4 +22,4 @@
           - stable
 
     - name: Add support for https transport
-      apt pkg="apt-transport-https" state=present update_cache=no
+      apt: pkg="apt-transport-https" state=present update_cache=no


### PR DESCRIPTION
This syntax error was causing `vagrant up osmocom` to fail.