### PR TITLE
Client and cloud documentation updates

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -12,7 +12,7 @@ To get started, you should install
 
 [Vagrant](http://www.vagrantup.com/downloads.html)
 
-and [Ansible](http://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
+and [Ansible](>= 2.4)(http://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
 
 so you can establish a development environment. The build has been
 validated against vagrant 2.1.1, ansible 2.5.3.

--- a/client/README.md
+++ b/client/README.md
@@ -37,9 +37,9 @@ all your build deps. Osmocom is suitable for most testing purposes, even
 if Osmocom-compatible hardware is not available.
 
 It is STRONGLY RECOMMENDED that the initial installation of client
-software within the VM is accomplished using `apt-get` to download the
+software within the VM (`vagrant ssh [osmocom|openbts]`) is accomplished using `apt-get` to download the
 appropriate top-level package, to ensure that all dependencies are
-automatically satisfied. Install `endaga-osmocom` as follows: `apt-get
+automatically satisfied. Install `endaga-osmocom` as follows: `sudo apt-get
 install endaga-osmocom`.
 
 To build everything from source (i.e., what you have checked out on

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -11,11 +11,11 @@ Setting up for development
 [awscli](https://pypi.python.org/pypi/awscli) and
 [ansible](http://docs.ansible.com/):
 
-    apt-get install python-pip
-    pip install fabric
-    pip install awscli
-    pip install ansible
-    git update-index --assume-unchanged envdir/*
+        apt-get install python-pip
+        pip install fabric
+        pip install awscli
+        pip install ansible
+        git update-index --assume-unchanged envdir/*
 
 The last command (`git update-index`) allows you to make changes as
 necessary to your envdir without worrying about having those changes
@@ -36,11 +36,11 @@ so you can establish a development environment.  Once you've installed
 vagrant, just run `vagrant up` and a development box will be created
 based on the Vagrantfile in this repo.  This will launch five servers:
 
-`web`
-`db` (a PostgreSQL database)
-'vpn' (openvpn)
-'cert' (a certifier/signing service)
-`rmq` (a RabbitMQ broker).
+- `web`
+- `db` (a PostgreSQL database)
+- `vpn` (openvpn)
+- `cert` (a certifier/signing service)
+- `rmq` (a RabbitMQ broker).
 
 For example, to connect to the VM running the dev environment, you'd
 run `vagrant ssh web`.
@@ -60,8 +60,8 @@ if you need.
 
 4) On the web VM, use the development environment:
 
-    cd ~/cloud
-    workon endaga
+        cd ~/cloud
+        workon endaga
 
 The 'endaga' virtual environment MUST be used to run the Django
 server; Django is not installed in the root system.


### PR DESCRIPTION
Mentions Ansible >= 2.4
Mentions `sudo` for `apt`
Makes the first mention of `vagrant ssh` come earlier
Fixes line break rendering on Github